### PR TITLE
Fix: Ensure direct navigation to book pages works

### DIFF
--- a/src/services/BookService.js
+++ b/src/services/BookService.js
@@ -13,6 +13,32 @@ export default {
   getNovels() {
     return apiClient.get("");
   },
+  async getNovelBySlug(slug) {
+    try {
+      const response = await apiClient.get("");
+      const books = response.data;
+      let foundNovel = null;
+
+      if (Array.isArray(books)) {
+        foundNovel = books.find(book => book.slug === slug);
+      } else if (typeof books === 'object' && books !== null) {
+        // Case 1: books is an object keyed by slug
+        if (books[slug] && books[slug].slug === slug) {
+          foundNovel = books[slug];
+        }
+        // Case 2: books is an object keyed by something else (e.g., ID),
+        // and values are book objects with a 'slug' property.
+        else {
+          foundNovel = Object.values(books).find(book => book.slug === slug);
+        }
+      }
+      return foundNovel || null; // Ensure null is returned if not found
+    } catch (error) {
+      console.error("Error fetching novel by slug:", error);
+      //throw error; // Re-throw or return null/error object as per desired error handling
+      return null; // For this task, returning null on error is consistent with "not found"
+    }
+  },
   postNovels(novel) {
     return apiClient.post('/novels', novel)
   }


### PR DESCRIPTION
Previously, navigating directly to a book's URL (e.g., /book-slug) would result in an error because the BookDetail component was not correctly handling the slug parameter or fetching data appropriately.

This commit addresses the issue by:
1. Modifying `BookDetail.vue` to correctly use the `slug` prop passed by the router, instead of `id`.
2. Updating the data fetching mechanism in `BookDetail.vue` to find a book by its `slug` from the list of all books. Includes error handling to redirect to a 404 page if a book is not found.
3. Ensuring Firebase interactions (ratings, marking as read) consistently use the book slug as the identifier.
4. Refactoring book fetching logic by adding a `getNovelBySlug(slug)` method to `BookService.js`. This centralizes the logic of retrieving a single book by its slug, even though it still fetches all books from the backend due to the current data structure. `BookDetail.vue` was updated to use this new service method.

These changes allow you to directly access book pages via their slugs, improving the user experience and navigability of the application.