### PR TITLE
Fix: Prevent Firebase 'empty path' error in BookDetail

### DIFF
--- a/src/services/BookService.js
+++ b/src/services/BookService.js
@@ -32,7 +32,17 @@ export default {
           foundNovel = Object.values(books).find(book => book.slug === slug);
         }
       }
-      return foundNovel || null; // Ensure null is returned if not found
+
+      // Validate the slug of the found novel
+      if (foundNovel) {
+        // Check if slug exists, is a string, and is not empty (after trimming)
+        if (!foundNovel.slug || typeof foundNovel.slug !== 'string' || foundNovel.slug.trim() === '') {
+          console.warn(`Found novel with invalid or empty slug. Input slug: "${slug}", Found slug: "${foundNovel.slug}". Treating as not found.`);
+          foundNovel = null; // Invalidate if slug is not a non-empty string
+        }
+      }
+
+      return foundNovel || null; // Ensure null is returned if not found or if invalidated
     } catch (error) {
       console.error("Error fetching novel by slug:", error);
       //throw error; // Re-throw or return null/error object as per desired error handling

--- a/src/views/BookDetail.vue
+++ b/src/views/BookDetail.vue
@@ -44,10 +44,21 @@ export default {
       if (novel) {
         this.novel = novel;
 
-        // Now that novel is found, fetch its rating
+        // Validate novel slug and user UID before Firebase call
+        const novelSlug = this.novel.slug;
+        const userUID = this.$store.state.user.user.userinfo;
+
+        if (typeof novelSlug !== 'string' || novelSlug.trim() === '' ||
+            typeof userUID !== 'string' || userUID.trim() === '') {
+          console.error(`Invalid novel slug or user UID for Firebase path. Slug: "${novelSlug}", UserInfo: "${userUID}"`);
+          this.$router.push({ name: '404' });
+          return; // Stop further execution in this block
+        }
+
+        // Now that novel is found and IDs are validated, fetch its rating
         const db = firebase.firestore();
-        // Use this.novel.slug for consistency and safety
-        var docRef = db.collection("rating").doc(this.novel.slug).collection("users").doc(this.$store.state.user.user.userinfo);
+        // Use validated novelSlug and userUID
+        var docRef = db.collection("rating").doc(novelSlug).collection("users").doc(userUID);
         
         docRef.get().then((doc) => {
           if (doc.exists) {


### PR DESCRIPTION
This commit addresses a FirebaseError:
'Function CollectionReference.doc() cannot be called with an empty path.' that occurred in the BookDetail component's created() hook when you navigated directly to a book slug.

The error was caused by attempting to construct a Firestore document path using either `this.novel.slug` or `this.$store.state.user.user.userinfo` when one or both of these values were empty or invalid.

The fix includes:
1.  In `BookDetail.vue`:
    *   Added explicit checks within the `created()` hook to ensure that
      `this.novel.slug` and `this.$store.state.user.user.userinfo` are
      non-empty strings before they are used in Firestore document paths.
    *   If either value is invalid, an error is logged, and the component
      redirects to the '404' page, preventing the Firebase call.

2.  In `BookService.js`:
    *   Enhanced the `getNovelBySlug(slug)` method to further validate
      the `slug` property of any book object it finds. If a book is
      found that matches the input slug, but its own `slug` property
      is missing, not a string, or an empty string, it's treated as
      "not found," and `null` is returned. This adds an extra layer
      of robustness.

These changes ensure that Firestore document paths are always constructed with valid, non-empty segments, resolving the error and improving the stability of direct book page navigation.